### PR TITLE
Added discovery of queryables

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ This extension adds a few additional parameters for convenience.
 Collections shall advertise the query parameters they support at the `/collections/{collection-id}/queryables` endpoint that 
 shall return a JSON Schema document as defined in [OGC API-Features - Part 3:Filtering](https://docs.opengeospatial.org/DRAFTS/19-079r1.html#filter-queryables).
 
-
 ## STAC Collections
 
 ### Collection Properties


### PR DESCRIPTION
Added /queryables endpoints as provided by API-Records (via API - Features - Part 3) which has a similar role as an OSDD publishing the available search parameters (for collection search or for item search in a particular collection).